### PR TITLE
Add invalidation service to user role permissions 

### DIFF
--- a/haplo_user_roles_permissions/js/haplo_user_roles_permissions.js
+++ b/haplo_user_roles_permissions/js/haplo_user_roles_permissions.js
@@ -189,6 +189,11 @@ P.hook("hPostObjectChange", function(response, object, operation, previous) {
     }
 });
 
+// Allow other plugins to flush cache ie, if adding to roles with add_roles_to_user
+P.implementService("haplo:user_roles_permissions:invalidate_user_roles_cache", function() {
+    invalidateUserRolesCache.signal();
+});
+
 // --------------------------------------------------------------------------
 
 var UserRoles = function(userId, userRef) {


### PR DESCRIPTION
Allows other plugins to invalidate the cache when adding roles with add_roles_to_user

Fixes #1 